### PR TITLE
Update nLogLike.cpp

### DIFF
--- a/src/nLogLike.cpp
+++ b/src/nLogLike.cpp
@@ -91,7 +91,7 @@ double nLogLike_rcpp(int nbStates, arma::mat beta, arma::mat covs, DataFrame dat
 
         arma::mat diag(nbStates,nbStates);
         diag.eye(); // diagonal of ones
-        arma::mat Gamma = trMat.slice(0); // all slices are identical if stationary
+        arma::mat Gamma = trMat.slice(0).t(); // all slices are identical if stationary
         arma::colvec v(nbStates);
         v.ones(); // vector of ones
         try {


### PR DESCRIPTION
When stationary=TRUE, mle$delta in fitHMM and delta in nLogLike.cpp are not the same.  In fitHMM, mle$delta <- solve(t(diag(nbStates)-gamma+1),rep(1,nbStates)), but in nLogLike.cpp, delta = arma::solve(diag-Gamma+1,v).t().  This fix makes them the same.