### PR TITLE
clarify expected order of trackData

### DIFF
--- a/R/prepData.R
+++ b/R/prepData.R
@@ -5,7 +5,8 @@
 #' (either longitude/latitude values or cartesian coordinates), and optionnaly a field \code{ID}
 #' (identifiers for the observed individuals). Additionnal fields are considered as covariates.
 #' Note that, if the names of the coordinates are not "x" and "y", the \code{coordNames} argument
-#' should specified.
+#' should specified. Tracking data should be structured so that the rows for each track (or each animal) 
+#' are grouped together, and ordered by date, in the data frame.
 #' @param type \code{'LL'} if longitude/latitude provided (default), \code{'UTM'} if easting/northing.
 #' @param coordNames Names of the columns of coordinates in the data frame. Default: \code{c("x","y")}.
 #' @param LLangle Logical. If TRUE, the turning angle is calculated with \code{geosphere::bearing}


### PR DESCRIPTION
Just a small edit to the man for `prepData`. 
I think it is worth explicitly clarifying the expected data structure (ordered by ID, then date) to avoid users hitting this roadblock with an important function in the package. 

Described here on [SO](https://stackoverflow.com/questions/57801154/error-in-prepdata-function-in-package-movehmm-contiguous-data) by @TheoMichelot.