### PR TITLE
Fix bug in prepData when using tibbles (#22)

### DIFF
--- a/R/prepData.R
+++ b/R/prepData.R
@@ -5,7 +5,7 @@
 #' (either longitude/latitude values or cartesian coordinates), and optionnaly a field \code{ID}
 #' (identifiers for the observed individuals). Additionnal fields are considered as covariates.
 #' Note that, if the names of the coordinates are not "x" and "y", the \code{coordNames} argument
-#' should specified. Tracking data should be structured so that the rows for each track (or each animal) 
+#' should specified. Tracking data should be structured so that the rows for each track (or each animal)
 #' are grouped together, and ordered by date, in the data frame.
 #' @param type \code{'LL'} if longitude/latitude provided (default), \code{'UTM'} if easting/northing.
 #' @param coordNames Names of the columns of coordinates in the data frame. Default: \code{c("x","y")}.
@@ -37,7 +37,7 @@ prepData <- function(trackData, type=c('LL','UTM'), coordNames=c("x","y"), LLang
     if(length(which(coordNames %in% names(trackData)))<2)
         stop("Check the columns names of your coordinates.")
 
-    if(!is.null(trackData$ID))
+    if("ID" %in% colnames(trackData))
         ID <- as.character(trackData$ID) # homogenization of numeric and string IDs
     else
         ID <- rep("Animal1",nrow(trackData)) # default ID if none provided
@@ -64,8 +64,8 @@ prepData <- function(trackData, type=c('LL','UTM'), coordNames=c("x","y"), LLang
         }
     }
 
-    x <- trackData[,coordNames[1]]
-    y <- trackData[,coordNames[2]]
+    x <- trackData[[coordNames[1]]]
+    y <- trackData[[coordNames[2]]]
 
     nbAnimals <- length(unique(ID))
 

--- a/tests/testthat/test_prepData.R
+++ b/tests/testthat/test_prepData.R
@@ -37,3 +37,13 @@ test_that("The returned object is of the correct class",{
 
     expect_equal(class(data),c("moveData","data.frame"))
 })
+
+test_that("Accepts tibble inputs", {
+    set.seed(10)
+    x <- runif(10)
+    y <- runif(10)
+    tracks_df <- data.frame(x, y)
+    tracks_tbl <- dplyr::tibble(x, y)
+
+    expect_equal(prepData(tracks_tbl), prepData(tracks_df))
+})


### PR DESCRIPTION
This fixes a bug when tracking data is in a `tibble` instead of a `data.frame`. The main code change is on lines 67-68. Row-column subsetting a `data.frame` simplifies to a vector if there's only one column, but the same for a `tibble` returns another `tibble`. See example below. The change on line 40 avoids a warning when trying to get a non-existent column from a `tibble`. I also added a unit test. Unfortunately, I can't get moveHMM to build properly on my system, so I wasn't able to run R CMD CHECK or the full test suite. Hope this helps!

``` r
data.frame(x = 1:3)[, "x"]
#> [1] 1 2 3
dplyr::tibble(x = 1:3)[, "x"]
#> # A tibble: 3 x 1
#>       x
#>   <int>
#> 1     1
#> 2     2
#> 3     3
dplyr::tibble(x = 1:3)[["x"]]
#> [1] 1 2 3
```

<sup>Created on 2021-09-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>